### PR TITLE
Added support for residual connections

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,13 @@
 model:
   layers:
     - 784
+    - 50
+    - 50
     - 10
+  residual_connections:
+    - False
+    - True
+    - False
   tau_mem: 20.
   tau_stdp: 10.
   alpha_stdp: 1.


### PR DESCRIPTION
Now residual connections between layers of the same size can be added. In particular, in the config file you can add an optional parameter `residual_connections` followed by a list of bools, indicating whether each connection should or not be a residual connection.

Additionally, now Q is updated after every optimization step.